### PR TITLE
IMTA-4762: owasp dependency-check and jacoco plugins defined in parent pom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,6 @@
     <maven.compiler.source.version>1.8</maven.compiler.source.version>
     <maven.compiler.target.version>1.8</maven.compiler.target.version>
     <jacoco.maven.plugin.version>0.8.0</jacoco.maven.plugin.version>
-    <owasp.version>3.3.2</owasp.version>
     <surefire.version>2.14.1</surefire.version>
     <maven.resources.plugin.version>3.1.0</maven.resources.plugin.version>
     <surefire.version>2.20</surefire.version>
@@ -55,6 +54,7 @@
     <mssql.jdbc.version>7.0.0.jre8</mssql.jdbc.version>
     <io.micrometer.micrometer-core.version>1.1.2</io.micrometer.micrometer-core.version>
     <azure.springboot.metricsstarter.version>2.1.2</azure.springboot.metricsstarter.version>
+    <owasp.version>4.0.2</owasp.version>
   </properties>
 
   <dependencyManagement>
@@ -353,5 +353,16 @@
         </plugin>
       </plugins>
     </pluginManagement>
+
+    <plugins>
+      <plugin>
+        <groupId>org.jacoco</groupId>
+        <artifactId>jacoco-maven-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <groupId>org.owasp</groupId>
+        <artifactId>dependency-check-maven</artifactId>
+      </plugin>
+    </plugins>
   </build>
 </project>


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | jon lee (WORTH SYSTEMS) |
> | **GitLab Project** | [imports/spring-boot-parent](https://giteux.azure.defra.cloud/imports/spring-boot-parent) |
> | **GitLab Merge Request** | [IMTA-4762: owasp dependency-check and ja...](https://giteux.azure.defra.cloud/imports/spring-boot-parent/merge_requests/5) |
> | **GitLab MR Number** | [5](https://giteux.azure.defra.cloud/imports/spring-boot-parent/merge_requests/5) |
> | **Date Originally Opened** | Thu, 11 Apr 2019 |
> | **Approved on GitLab by** | ian homer (WORTH SYSTEMS), raashid mohammed (WORTH SYSTEMS) |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

I verified this worked by:
1. running `mvn install` on this project
2. in countries-microservice (which at the moment does not have jacoco or dependency-check plugins configured) I altered the pom to use 1.0.4-SNAPSHOT parent
3. in countries-microservice/service I ran `mvn clean test jacoco:report`
4. I checked that jacoco.exec had been output in the target directory and the reports in target/site/jacoco
5. in countries-microservice/service I can `mvn clean dependency-check:check`
6. I checked that dependency-check-report.html had been output in the target directory