### PR TITLE
IMTA-5626: Updating notification schema version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
 
     <tracesx.common.version>2.0.1</tracesx.common.version>
     <tracesx.common.security.version>2.0.0</tracesx.common.security.version>
-    <tracesx.notification.schema.version>1.0.40</tracesx.notification.schema.version>
+    <tracesx.notification.schema.version>1.0.42</tracesx.notification.schema.version>
 
     <!-- Spring Boot dependency version overrides -->
     <jackson.version>2.9.10</jackson.version>


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | Sean Treanor (KAINOS) |
> | **GitLab Project** | [imports/spring-boot-parent](https://giteux.azure.defra.cloud/imports/spring-boot-parent) |
> | **GitLab Merge Request** | [IMTA-5626: Updating notification schema ...](https://giteux.azure.defra.cloud/imports/spring-boot-parent/merge_requests/24) |
> | **GitLab MR Number** | [24](https://giteux.azure.defra.cloud/imports/spring-boot-parent/merge_requests/24) |
> | **Date Originally Opened** | Wed, 30 Oct 2019 |
> | **Approved on GitLab by** | Mateusz Kalinowski, Stephen Donaghey (KAINOS), daniel brennan (KAINOS) |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

* Changing notification schema version from `1.0.40` to `1.0.42` to get newest schema changes.