### PR TITLE
IMTA-6701: Add maven dependency plugin to parent pom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -70,6 +70,8 @@
     <surefire.junit4.version>2.22.0</surefire.junit4.version>
     <testng.version>6.14.3</testng.version>
     <client.runtime.version>1.6.15</client.runtime.version>
+    <maven-dependency-plugin.version>3.1.1</maven-dependency-plugin.version>
+    <maven-dependency-analyzer.version>1.11.1</maven-dependency-analyzer.version>
   </properties>
 
   <dependencyManagement>
@@ -400,6 +402,17 @@
   <build>
     <pluginManagement>
       <plugins>
+        <plugin>
+          <artifactId>maven-dependency-plugin</artifactId>
+          <version>${maven-dependency-plugin.version}</version>
+          <dependencies>
+            <dependency>
+              <groupId>org.apache.maven.shared</groupId>
+              <artifactId>maven-dependency-analyzer</artifactId>
+              <version>${maven-dependency-analyzer.version}</version>
+            </dependency>
+          </dependencies>
+        </plugin>
         <plugin>
           <artifactId>maven-release-plugin</artifactId>
           <version>${maven-release-plugin.version}</version>


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | iwan roberts (KAINOS) |
> | **GitLab Project** | [imports/spring-boot-parent](https://giteux.azure.defra.cloud/imports/spring-boot-parent) |
> | **GitLab Merge Request** | [IMTA-6701: Add maven dependency plugin t...](https://giteux.azure.defra.cloud/imports/spring-boot-parent/merge_requests/51) |
> | **GitLab MR Number** | [51](https://giteux.azure.defra.cloud/imports/spring-boot-parent/merge_requests/51) |
> | **Date Originally Opened** | Mon, 24 Feb 2020 |
> | **Approved on GitLab by** | Stephen Donaghey (KAINOS), dominik henjes (KAINOS), kamil mojek (KAINOS) |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

This change will allow us to use maven to track our dependencies more effectively, plus identify dependencies that we are not using. As part of IMTA-6701 it will allow us to force a service rebuild when the configuration container is modified.

http://maven.apache.org/plugins/maven-dependency-plugin/index.html