### PR TITLE
IMTA-8976: - OWASP HIGH - upgrade versions of Spring Boot

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>2.3.2.RELEASE</version>
+    <version>2.4.2</version>
   </parent>
 
   <distributionManagement>
@@ -33,9 +33,9 @@
 
     <java.version>11</java.version>
 
-    <tracesx.common.version>2.0.18</tracesx.common.version>
-    <tracesx.common.security.version>2.0.8</tracesx.common.security.version>
-    <tracesx.notification.schema.version>1.0.141</tracesx.notification.schema.version>
+    <tracesx.common.version>2.0.19</tracesx.common.version>
+    <tracesx.common.security.version>2.0.9</tracesx.common.security.version>
+    <tracesx.notification.schema.version>1.0.143</tracesx.notification.schema.version>
     <adal4j.version>1.6.4</adal4j.version>
     <applicationinsights.version>2.6.2</applicationinsights.version>
     <azure.springboot.metricsstarter.version>2.1.7</azure.springboot.metricsstarter.version>
@@ -44,14 +44,13 @@
     <commons.beanutils.version>1.9.4</commons.beanutils.version>
     <com.mashape.unirest.version>1.4.9</com.mashape.unirest.version>
     <equalsverifier.version>2.4.8</equalsverifier.version>
-    <guava.version>24.1.1-jre</guava.version>
+    <guava.version>30.1-jre</guava.version>
     <io.micrometer.micrometer-core.version>1.5.3</io.micrometer.micrometer-core.version>
     <jacoco.maven.plugin.version>0.8.2</jacoco.maven.plugin.version>
     <jjwt.version>0.10.5</jjwt.version>
     <json.patch.version>1.9</json.patch.version>
     <json-schema-java7.version>1.4.1</json-schema-java7.version>
     <junit.jupiter.version>5.0.2</junit.jupiter.version>
-    <jwks-rsa.version>0.3.0</jwks-rsa.version>
     <maven.checkstyle.version>3.0.0</maven.checkstyle.version>
     <maven-release-plugin.version>2.5.3</maven-release-plugin.version>
     <mockito.version>2.28.2</mockito.version>
@@ -59,8 +58,7 @@
     <neovisionaries.version>1.22</neovisionaries.version>
     <org.everit.json.schema.version>1.12.1</org.everit.json.schema.version>
     <org.owasp.encoder.version>1.2.2</org.owasp.encoder.version>
-    <owasp.version>6.0.1</owasp.version>
-    <spring.security.jwt.version>1.0.10.RELEASE</spring.security.jwt.version>
+    <owasp.version>6.0.5</owasp.version>
     <surefire.junit4.version>2.22.0</surefire.junit4.version>
     <testng.version>6.14.3</testng.version>
     <client.runtime.version>1.6.15</client.runtime.version>
@@ -99,16 +97,6 @@
         <groupId>uk.gov.defra.tracesx</groupId>
         <artifactId>notification-schema-java</artifactId>
         <version>${tracesx.notification.schema.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.springframework.security</groupId>
-        <artifactId>spring-security-jwt</artifactId>
-        <version>${spring.security.jwt.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>com.auth0</groupId>
-        <artifactId>jwks-rsa</artifactId>
-        <version>${jwks-rsa.version}</version>
       </dependency>
       <dependency>
         <groupId>commons-beanutils</groupId>
@@ -161,6 +149,12 @@
         <groupId>com.microsoft.rest</groupId>
         <artifactId>client-runtime</artifactId>
         <version>${client.runtime.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
       <dependency>
         <groupId>com.github.fge</groupId>
@@ -314,11 +308,21 @@
     <dependency>
       <groupId>com.github.fge</groupId>
       <artifactId>json-patch</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>com.google.guava</groupId>
+          <artifactId>guava</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.projectlombok</groupId>
       <artifactId>lombok</artifactId>
       <type>jar</type>
+    </dependency>
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
     </dependency>
     <!-- TODO: IMTS-4606 It would be nice to have a separate persistence parent -->
     <dependency>


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | bridget.hodgson (Kainos) |
> | **GitLab Project** | [imports/spring-boot-parent](https://giteux.azure.defra.cloud/imports/spring-boot-parent) |
> | **GitLab Merge Request** | [IMTA-8976: - OWASP HIGH - upgrade versio...](https://giteux.azure.defra.cloud/imports/spring-boot-parent/merge_requests/145) |
> | **GitLab MR Number** | [145](https://giteux.azure.defra.cloud/imports/spring-boot-parent/merge_requests/145) |
> | **Date Originally Opened** | Thu, 21 Jan 2021 |
> | **Approved on GitLab by** | Karimou Lawani (kainos), Reece Bennett (KAINOS), Stephen Donaghey (KAINOS) |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

* https://eaflood.atlassian.net/browse/IMTA-8976
* Upgrading Spring Boot version
* Upgrading Spring Boot Common Security version (our Jar)
* Upgrading Spring Boot Common version (our Jar)
* This is to fix numerous OWASP issues, see Jira ticket for the list.
* Also upgraded the version of the OWASP dependancy check from 6.0.1 to 6.0.5
