### PR TITLE
IMTA-9432: Validation if POD country not selected

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
 
     <tracesx.common.version>2.0.20</tracesx.common.version>
     <tracesx.common.security.version>2.0.12</tracesx.common.security.version>
-    <tracesx.notification.schema.version>1.0.176</tracesx.notification.schema.version>
+    <tracesx.notification.schema.version>1.0.177</tracesx.notification.schema.version>
     <adal4j.version>1.6.4</adal4j.version>
     <applicationinsights.version>2.6.2</applicationinsights.version>
     <azure.springboot.metricsstarter.version>2.1.7</azure.springboot.metricsstarter.version>


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | Juliano Saunders (Kainos) |
> | **GitLab Project** | [imports/spring-boot-parent](https://giteux.azure.defra.cloud/imports/spring-boot-parent) |
> | **GitLab Merge Request** | [IMTA-9432: Validation if POD country not...](https://giteux.azure.defra.cloud/imports/spring-boot-parent/merge_requests/183) |
> | **GitLab MR Number** | [183](https://giteux.azure.defra.cloud/imports/spring-boot-parent/merge_requests/183) |
> | **Date Originally Opened** | Wed, 12 May 2021 |
> | **Approved on GitLab by** | Kamesh Ganesan (KAINOS), Kelly Moore, Stephen McVeigh, iwan roberts (KAINOS) |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

### :link:  [Ticket](https://eaflood.atlassian.net/browse/IMTA-9432)

### :book: Changes
* Bumb version of schema for adding two validation rules:
 * invalid pod due to non pod group country
 * pod required when selecting pod in Inspection premise field