### PR TITLE
IMTA-9365 Update Mockito version to 3.11.2 to allow static method mocking

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
     <junit.jupiter.version>5.0.2</junit.jupiter.version>
     <maven.checkstyle.version>3.0.0</maven.checkstyle.version>
     <maven-release-plugin.version>2.5.3</maven-release-plugin.version>
-    <mockito.version>2.28.2</mockito.version>
+    <mockito.version>3.11.2</mockito.version>
     <mssql.jdbc.version>7.4.1.jre11</mssql.jdbc.version>
     <neovisionaries.version>1.22</neovisionaries.version>
     <org.everit.json.schema.version>1.12.1</org.everit.json.schema.version>


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | Stephen Donaghey (KAINOS) |
> | **GitLab Project** | [imports/spring-boot-parent](https://giteux.azure.defra.cloud/imports/spring-boot-parent) |
> | **GitLab Merge Request** | [IMTA-9365 Update Mockito version to 3.11...](https://giteux.azure.defra.cloud/imports/spring-boot-parent/merge_requests/200) |
> | **GitLab MR Number** | [200](https://giteux.azure.defra.cloud/imports/spring-boot-parent/merge_requests/200) |
> | **Date Originally Opened** | Thu, 22 Jul 2021 |
> | **Approved on GitLab by** | Callum Atwal (kainos), Marcin Kaminski (kainos), Reece Bennett (KAINOS), dominik henjes (KAINOS), iwan roberts (KAINOS) |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

### :link: Ticket: https://eaflood.atlassian.net/browse/IMTA-9365

### :book: Changes:
* Upgrading wiremock to 3.11.2 to make use of in-built static method mocking.