### PR TITLE
IMTA-11688: Update spring-boot-starter-parent to v.2.6.6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>2.6.2</version>
+    <version>2.6.6</version>
   </parent>
 
   <distributionManagement>


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | Marc-Steeven Eyeni-Kantsey (Kainos) |
> | **GitLab Project** | [imports/spring-boot-parent](https://giteux.azure.defra.cloud/imports/spring-boot-parent) |
> | **GitLab Merge Request** | [IMTA-11688: Update spring-boot-starter-p...](https://giteux.azure.defra.cloud/imports/spring-boot-parent/merge_requests/238) |
> | **GitLab MR Number** | [238](https://giteux.azure.defra.cloud/imports/spring-boot-parent/merge_requests/238) |
> | **Date Originally Opened** | Thu, 21 Apr 2022 |
> | **Approved on GitLab by** | James Taylor, Joshua Craig (Kainos), akbar shaik (Kainos) |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

Update spring-boot-starter-parent package to v.2.6.6