### PR TITLE
IMTA-12099: Publish Spring Boot Parent code in the open

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,8 @@
+The Open Government Licence (OGL) Version 3
+
+Copyright (c) 2021 Defra
+
+This source code is licensed under the Open Government Licence v3.0. To view this
+licence, visit www.nationalarchives.gov.uk/doc/open-government-licence/version/3
+or write to the Information Policy Team, The National Archives, Kew, Richmond,
+Surrey, TW9 4DU.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,29 @@
+# Spring Boot Parent
+
+## Introduction
+This repository contains the parent POM for Java based IPAFFS repositories, it extends the POM provided by Spring Boot
+
+## Secret scanning
+Secret scanning is setup using [truffleHog](https://github.com/trufflesecurity/truffleHog).
+It is used as a pre-push hook and will scan any local commits being pushed
+
+### Pre-push hook setup
+1. Install [truffleHog](https://github.com/trufflesecurity/truffleHog)
+    - `brew install go`
+    - `git clone https://github.com/trufflesecurity/trufflehog.git`
+    - `cd trufflehog; go install`
+2. Set DEFRA_WORKSPACE env var (`export DEFRA_WORKSPACE=/path/to/workspace`)
+3. Potentially there's an older version of Trufflehog located at: `/usr/local/bin/trufflehog`. If so, remove this.
+4. Create a symlink: `ln -s ~/go/bin/truffleHog /usr/local/bin/trufflehog`
+5. From this project root directory copy the pre-push hook: `cp hooks/pre-push .git/hooks/pre-push`
+
+### Steps to integrate
+Include the following in the pom.xml of your spring boot service
+
+```
+<parent>
+  <groupId>uk.gov.defra.tracesx</groupId>
+  <artifactId>spring-boot-parent</artifactId>
+  <version>desired version</version>
+</parent>
+```

--- a/hooks/pre-push
+++ b/hooks/pre-push
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+RED='\033[0;31m'
+NO_COLOUR='\033[0m'
+LOG_PREFIX="Pre-push hook:"
+FAILED_MESSAGE="${LOG_PREFIX} ${RED}[FAILED]${NO_COLOUR}"
+REPO_NAME="spring-boot-parent"
+
+trufflehog --help > /dev/null 2>&1 || { echo -e "${FAILED_MESSAGE} truffleHog is not installed. Please install via https://github.com/trufflesecurity/truffleHog" ; exit 1; }
+[ -z "$DEFRA_WORKSPACE" ] && echo -e "${FAILED_MESSAGE} Please set DEFRA_WORKSPACE env var to your Defra workspace" && exit 1;
+
+echo "${LOG_PREFIX} RUNNING truffleHog to test for leaked secrets."
+trufflehog git --fail --regex --since_commit "$(git rev-parse origin/HEAD)" --branch "$(git rev-parse --abbrev-ref HEAD)" file://"${DEFRA_WORKSPACE}"/${REPO_NAME}
+exit_code=$?
+
+if [[ $exit_code -ne 0 ]]; then
+  echo -e "${FAILED_MESSAGE} truffleHog found some suspicious commits containing possible secrets"
+  echo -e "${FAILED_MESSAGE} git push failed, Please remove the secrets caught by truffleHog"
+  exit 1
+else
+  echo "${LOG_PREFIX} OK proceeding with push"
+  exit 0
+fi

--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,7 @@
     <neovisionaries.version>1.22</neovisionaries.version>
     <org.everit.json.schema.version>1.12.1</org.everit.json.schema.version>
     <org.owasp.encoder.version>1.2.2</org.owasp.encoder.version>
-    <owasp.version>6.0.5</owasp.version>
+    <owasp.version>6.5.3</owasp.version>
     <surefire.junit4.version>2.22.0</surefire.junit4.version>
     <testng.version>6.14.3</testng.version>
     <client.runtime.version>1.6.15</client.runtime.version>


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | Jahir, Sifat (KAINOS) |
> | **GitLab Project** | [imports/spring-boot-parent](https://giteux.azure.defra.cloud/imports/spring-boot-parent) |
> | **GitLab Merge Request** | [IMTA-12099: Publish Spring Boot Parent c...](https://giteux.azure.defra.cloud/imports/spring-boot-parent/merge_requests/247) |
> | **GitLab MR Number** | [247](https://giteux.azure.defra.cloud/imports/spring-boot-parent/merge_requests/247) |
> | **Date Originally Opened** | Fri, 24 Jun 2022 |
> | **Approved on GitLab by** | Ben Doherty (Kainos), Blakeley, Paul (Kainos), Nicholas Martin, Thomas Seelig (Kainos), lee mason (KAINOS) |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

### :link: [Jira Ticket](https://eaflood.atlassian.net/browse/IMTA-12099)

### :building_construction: [Jenkins Pipeline](https://jenkins-imports.azure.defra.cloud/job/spring-boot-parent/job/feature%2FIMTA-12099-code-in-the-open/)

### :book: Changes:
- Added license file to the project
- Added trufflehog script and git commit hook
- Bump owasp version