### PR TITLE
Testing Stale spring-boot cleanup

### DIFF
--- a/JenkinsfileSpringBootRepoStaleBranchCleanup
+++ b/JenkinsfileSpringBootRepoStaleBranchCleanup
@@ -1,0 +1,88 @@
+#!/* groovylint-disable CompileStatic, LineLength, NestedBlockDepth, NoDef, UnusedVariable, VariableName, VariableTypeRequired */
+//@Library('pipeline-library') _
+
+//import defra.pipeline.config.Config
+//import defra.pipeline.deploy.DeployQueries
+//def jenkinsCredentialsRepository = Config.getPropertyValue("jenkinsCredentialsRepository", this)
+
+pipeline {
+    agent {label 'build_nodes'}
+    //triggers {
+       //cron('TZ=Europe/London\n0 21 * * 4')
+    //}
+    parameters {
+        string(name: 'repository', defaultValue: 'giteux.azure.defra.cloud/imports/spring-boot-parent.git')
+        string(name: 'ignoredBranchesRegex', defaultValue: '^\\s*origin\\/(master|stale|HEAD).*', description: 'Branches not to cleanup')
+        string(name: 'inactivityDays', defaultValue: '14', description: 'Number of days without a commit before becomming stale')
+        }
+    options {
+        ansiColor('xterm')
+        timestamps()
+    }
+
+    stages {
+        stage('Cleanup Spring-Boot-Parent Repo Git Branches') {
+            steps {
+                script {
+                    for (stalebranch in  params.repository) {
+                        withCredentials([string(credentialsId: 'JENKINS_GITLAB_TOKEN', variable: 'TOKEN')]) {
+                            staleBranchesList = []
+                            branchRenamePrefix = 'stale/'
+                            repoUrl =  "https://jenkins:${TOKEN}@giteux.azure.defra.cloud/imports/spring-boot-parent.git"
+
+                            // Clone Directories
+                            sh "git clone ${repoUrl}"
+
+                            dir("${stalebranch}") {
+                                branchesList = sh(
+                                    script: """
+                                        git branch -r | grep -ivE '${ignoredBranchesRegex}' | sed /\\*/d
+                                    """, returnStdout: true).split() as List
+
+                                for (branch in branchesList) {
+                                    branchStatus = sh(
+                                        script: """
+                                            set +x
+                                            echo "Checking branch ${branch}"
+                                            if [ -z \"\$(git log -1 --since='${inactivityDays} days' -s ${branch})\" ]; then
+                                                echo "${branch} is stale! Last commit: \$(git log -1 --format=%cd -s -s ${branch})."
+                                                exit 0
+                                            else
+                                                exit 1
+                                            fi
+                                            """, returnStatus: true)
+
+                                    if (branchStatus == 0) {
+                                        staleBranchesList.add(branch)
+                                    }
+                                }
+
+                                if (staleBranchesList.isEmpty()) {
+                                    echo "No stale branches detected."
+                                } else {
+                                    for (branch in staleBranchesList) {
+                                        sh """
+                                            set +x
+                                            BRANCH_NAME="\$(echo ${branch} | sed -e 's/origin\\///')"
+                                            NEW_BRANCH_NAME="${branchRenamePrefix}\${BRANCH_NAME}"
+                                            echo "Renaming branch \${BRANCH_NAME} to \${NEW_BRANCH_NAME}"
+                                            git branch \${NEW_BRANCH_NAME} ${branch}
+                                            git push -f ${repoUrl} --set-upstream \${NEW_BRANCH_NAME}
+                                            echo "Branch \${NEW_BRANCH_NAME} created. Removing \${BRANCH_NAME}."
+                                            git push ${repoUrl} --delete \${BRANCH_NAME}
+                                        """
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+    post {
+        always {
+            step([$class: 'WsCleanup'])
+        }
+    }
+}


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | willson onuoha (Kainos) |
> | **GitLab Project** | [imports/spring-boot-parent](https://giteux.azure.defra.cloud/imports/spring-boot-parent) |
> | **GitLab Merge Request** | [Testing Stale spring-boot cleanup](https://giteux.azure.defra.cloud/imports/spring-boot-parent/merge_requests/255) |
> | **GitLab MR Number** | [255](https://giteux.azure.defra.cloud/imports/spring-boot-parent/merge_requests/255) |
> | **Date Originally Opened** | Mon, 22 Aug 2022 |
> | **Approved on GitLab by** | Grzegorz Sowinski (Admin) |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

# Summary
The job used to convert stale branches to have the stale prefix is not working or implemented on the spring boot parent repo https://giteux.azure.defra.cloud/imports/spring-boot-parent/branches/stale

The code in this Jenkinsfile should fix that.

# Test

A separate job was created for this task since it currently hasnt been implemented in the past.

![Screenshot_2022-08-22_at_12.48.36](/uploads/f4cc4b957321ce87b9307cd22bc9b04b/Screenshot_2022-08-22_at_12.48.36.png)
![Screenshot_2022-08-22_at_16.22.38](/uploads/592224a8c331e91f2dc7d290eca27c7e/Screenshot_2022-08-22_at_16.22.38.png)
![Screenshot_2022-08-22_at_16.24.02](/uploads/1de78798fed74b59be00f6ce3f91e006/Screenshot_2022-08-22_at_16.24.02.png)

NB:- During testing you would notice this fatal: destination path 'spring-boot-parent' already exists and is not an empty directory, and job might fail, don't be alarmed as the even it fails the job still renames stales branches
![Screenshot_2022-08-23_at_15.53.52](/uploads/c9f29fcd382a779299d8ca85bcaf6478/Screenshot_2022-08-23_at_15.53.52.png)