### PR TITLE
IMTA-12699 : fix junit jupiter version issue by using 'spring-boot-starter-test' version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,6 @@
     <jjwt.version>0.10.5</jjwt.version>
     <json.patch.version>1.9</json.patch.version>
     <json-schema-java7.version>1.4.1</json-schema-java7.version>
-    <junit.jupiter.version>5.0.2</junit.jupiter.version>
     <maven.checkstyle.version>3.0.0</maven.checkstyle.version>
     <maven-release-plugin.version>2.5.3</maven-release-plugin.version>
     <mssql.jdbc.version>9.2.1.jre11</mssql.jdbc.version>
@@ -170,16 +169,6 @@
         <groupId>com.microsoft.sqlserver</groupId>
         <artifactId>mssql-jdbc</artifactId>
         <version>${mssql.jdbc.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.junit.jupiter</groupId>
-        <artifactId>junit-jupiter-engine</artifactId>
-        <version>${junit.jupiter.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.junit.jupiter</groupId>
-        <artifactId>junit-jupiter-params</artifactId>
-        <version>${junit.jupiter.version}</version>
       </dependency>
       <dependency>
         <groupId>org.apache.maven.surefire</groupId>


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | prabash balasuriya (kainos) |
> | **GitLab Project** | [imports/spring-boot-parent](https://giteux.azure.defra.cloud/imports/spring-boot-parent) |
> | **GitLab Merge Request** | [IMTA-12699 : fix junit jupiter version i...](https://giteux.azure.defra.cloud/imports/spring-boot-parent/merge_requests/257) |
> | **GitLab MR Number** | [257](https://giteux.azure.defra.cloud/imports/spring-boot-parent/merge_requests/257) |
> | **Date Originally Opened** | Tue, 13 Sep 2022 |
> | **Approved on GitLab by** | Kelly Moore, Reece Bennett (KAINOS), Thomas Seelig (Kainos), ramkumar ramagopal (Kainos) |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

### :link: [Jira Ticket](https://eaflood.atlassian.net/browse/IMTA-12699)

### :chart_with_upwards_trend: [SonarQube Report](<SONARQUBE LINK>)

### :building_construction: [Jenkins Pipeline](https://jenkins-imports.azure.defra.cloud/job/spring-boot-parent/job/feature%2FIMTA-12699-fix-junit-jupiter-version-issue/)

### :book: Changes:
* Remove explicitly defined 'junit-jupiter' version 
* Let 'junit-jupiter' version 5.8.2 to inherit directly from 'spring-boot-starter-test' project

### :white_check_mark: Selenium Test Run:

PENDING