### PR TITLE
IMTA-12801: Fixed vulnerability in spring boot starter security

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
     <java.version>11</java.version>
 
     <tracesx.common.version>2.0.24</tracesx.common.version>
-    <tracesx.common.security.version>2.0.14</tracesx.common.security.version>
+    <tracesx.common.security.version>2.0.17</tracesx.common.security.version>
     <tracesx.notification.schema.version>1.0.242</tracesx.notification.schema.version>
     <applicationinsights.version>2.6.3</applicationinsights.version>
     <azure.springboot.metricsstarter.version>2.3.5</azure.springboot.metricsstarter.version>
@@ -56,7 +56,7 @@
     <neovisionaries.version>1.22</neovisionaries.version>
     <org.everit.json.schema.version>1.12.1</org.everit.json.schema.version>
     <org.owasp.encoder.version>1.2.2</org.owasp.encoder.version>
-    <owasp.version>6.5.3</owasp.version>
+    <owasp.version>7.1.1</owasp.version>
     <surefire.junit4.version>2.22.0</surefire.junit4.version>
     <testng.version>6.14.3</testng.version>
     <client.runtime.version>1.6.15</client.runtime.version>


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | Conor McCormick (KAINOS) |
> | **GitLab Project** | [imports/spring-boot-parent](https://giteux.azure.defra.cloud/imports/spring-boot-parent) |
> | **GitLab Merge Request** | [IMTA-12801: Fixed vulnerability in sprin...](https://giteux.azure.defra.cloud/imports/spring-boot-parent/merge_requests/258) |
> | **GitLab MR Number** | [258](https://giteux.azure.defra.cloud/imports/spring-boot-parent/merge_requests/258) |
> | **Date Originally Opened** | Wed, 19 Oct 2022 |
> | **Approved on GitLab by** | Carl Evans (KAINOS), Charles.Luo, Marc-Steeven Eyeni-Kantsey (Kainos) |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

### :link: [Jira Ticket](https://eaflood.atlassian.net/browse/IMTA-12801)

### :chart_with_upwards_trend: [SonarQube Report](<SONARQUBE LINK>)

### :building_construction: [Jenkins Pipeline](https://jenkins-imports.azure.defra.cloud/job/spring-boot-parent/job/bugfix%2FIMTA-12801-vulnerability-in-spring-boot-starter-security/)

### :book: Changes:
* Bumped the `spring-boot-common-security` version to use [the new version](https://giteux.azure.defra.cloud/imports/spring-boot-common-security/merge_requests/42/diffs)
* Upgraded the OWASP scanner to prevent the vulnerability being identified as a false positive

Before
![image](/uploads/8655772dbee92ae274b20e71dc23d273/image.png)
After
![image](/uploads/5aa84c263a2b6c5ea4c26dbcc467845e/image.png)