### PR TITLE
IMTA-13157:add pre-commit hook for linting

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ It is used as a pre-push hook and will scan any local commits being pushed
 2. Set DEFRA_WORKSPACE env var (`export DEFRA_WORKSPACE=/path/to/workspace`)
 3. Potentially there's an older version of Trufflehog located at: `/usr/local/bin/trufflehog`. If so, remove this.
 4. Create a symlink: `ln -s ~/go/bin/truffleHog /usr/local/bin/trufflehog`
-5. From this project root directory copy the pre-push hook: `cp hooks/pre-push .git/hooks/pre-push`
+5. Run `mvn install` to configure hooks
 
 ### Steps to integrate
 Include the following in the pom.xml of your spring boot service

--- a/pom.xml
+++ b/pom.xml
@@ -57,13 +57,14 @@
     <neovisionaries.version>1.22</neovisionaries.version>
     <org.everit.json.schema.version>1.12.1</org.everit.json.schema.version>
     <org.owasp.encoder.version>1.2.2</org.owasp.encoder.version>
-    <owasp.version>7.1.1</owasp.version>
+    <owasp.version>7.4.4</owasp.version>
     <surefire.junit4.version>2.22.0</surefire.junit4.version>
     <testng.version>6.14.3</testng.version>
     <client.runtime.version>1.6.15</client.runtime.version>
     <maven-dependency-plugin.version>3.1.1</maven-dependency-plugin.version>
     <maven-dependency-analyzer.version>1.11.1</maven-dependency-analyzer.version>
     <log4j2.version>2.17.1</log4j2.version>
+    <git-build-hook-maven-plugin.version>3.3.0</git-build-hook-maven-plugin.version>
   </properties>
 
   <dependencyManagement>
@@ -540,6 +541,23 @@
             </execution>
           </executions>
         </plugin>
+        <plugin>
+          <groupId>com.rudikershaw.gitbuildhook</groupId>
+          <artifactId>git-build-hook-maven-plugin</artifactId>
+          <version>${git-build-hook-maven-plugin.version}</version>
+          <configuration>
+            <gitConfig>
+              <core.hooksPath>hooks</core.hooksPath>
+            </gitConfig>
+          </configuration>
+          <executions>
+            <execution>
+              <goals>
+                <goal>configure</goal>
+              </goals>
+            </execution>
+          </executions>
+        </plugin>
       </plugins>
     </pluginManagement>
 
@@ -555,6 +573,10 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-checkstyle-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <groupId>com.rudikershaw.gitbuildhook</groupId>
+        <artifactId>git-build-hook-maven-plugin</artifactId>
       </plugin>
     </plugins>
   </build>


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | Odran Muldoon (Kainos) |
> | **GitLab Project** | [imports/spring-boot-parent](https://giteux.azure.defra.cloud/imports/spring-boot-parent) |
> | **GitLab Merge Request** | [IMTA-13157:add pre-commit hook for linti...](https://giteux.azure.defra.cloud/imports/spring-boot-parent/merge_requests/264) |
> | **GitLab MR Number** | [264](https://giteux.azure.defra.cloud/imports/spring-boot-parent/merge_requests/264) |
> | **Date Originally Opened** | Mon, 9 Jan 2023 |
> | **Approved on GitLab by** | Apurva Jhunjhunwala (Kainos), Eugene Fahy (Kainos), Lewis Birks (Kainos), Marina Tihova, Reece Bennett (KAINOS) |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

### :link: [Jira Ticket](https://eaflood.atlassian.net/browse/IMTA-13157)

### :building_construction: [Jenkins Pipeline](https://jenkins-imports.azure.defra.cloud/job/spring-boot-parent/job/feature%2FIMTA-13157-adding-pre-commit-git-hook-for-linting/)

### :book: Changes:

- bump owasp version due to issue https://github.com/jeremylong/DependencyCheck/issues/5220
- add maven hook plugin