### PR TITLE
Add new code secret scanning stage for spring boot parent

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,3 +1,8 @@
+import defra.pipeline.config.Config;
+import defra.pipeline.deploy.DeployQueries;
+
+def deployables = DeployQueries.getListOfDeployableComponents(Config.getPropertyValue("secretscanningDeploymentList", this), this)
+
 @Library('pipeline-library') _
 
 pipeline {
@@ -17,6 +22,18 @@ pipeline {
   }
 
   stages {
+    stage('Code Secret Scanning'){
+        when {
+            expression {deployables.contains(SERVICE_NAME)}
+        }
+        steps {
+            build job: 'Code-secret-scanning',
+                parameters: [
+                    string(name: 'repository', value: "https://giteux.azure.defra.cloud/imports/$SERVICE_NAME" +".git"),
+                    string(name: 'branch', value: "master")
+                ]
+        }
+    }
 
     stage('Package') {
       steps {


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | willson onuoha (Kainos) |
> | **GitLab Project** | [imports/spring-boot-parent](https://giteux.azure.defra.cloud/imports/spring-boot-parent) |
> | **GitLab Merge Request** | [Add new code secret scanning stage for s...](https://giteux.azure.defra.cloud/imports/spring-boot-parent/merge_requests/265) |
> | **GitLab MR Number** | [265](https://giteux.azure.defra.cloud/imports/spring-boot-parent/merge_requests/265) |
> | **Date Originally Opened** | Mon, 9 Jan 2023 |
> | **Approved on GitLab by** | _No approvers_ |
> |      |      |
>
> This merge request was originally **closed** on GitLab

## Original Description

This new stage is required for scanning the master repository for any secret
password or token that shouldn't be made public