### PR TITLE
fix(ci): Report status to teams and use ephemeral nodes

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,79 +1,84 @@
-import defra.pipeline.config.Config;
-import defra.pipeline.deploy.DeployQueries;
+import defra.pipeline.config.Config
+import defra.pipeline.deploy.DeployQueries
 
 def deployables = DeployQueries.getListOfDeployableComponents(Config.getPropertyValue("secretscanningDeploymentList", this), this)
 
 @Library('pipeline-library') _
 
 pipeline {
-  agent {label 'swarm'}
-  environment {
-    SERVICE_NAME = "spring-boot-parent"
-  }
-  options {
-    ansiColor('xterm')
-    timestamps()
-    disableConcurrentBuilds()
-  }
-  parameters {
-      booleanParam(name: 'PUSH_TO_ARTIFACTORY', defaultValue: false, description: 'Do you want to push hotfix to artifactory?')
-      string(name: 'AFFECTED_VERSION', defaultValue: null, description: 'Enter affected version to be hotfixed e.g 2.0.103')
-      string(name: 'HOTFIX_VERSION', defaultValue: '1', description: 'Enter hotfix version (1 if it’s the 1st time patching this release version)')
-  }
-
-  stages {
-
-    stage('Code Secret Scanning'){
-      when {
-        expression {deployables.contains(SERVICE_NAME)}
-      }
-      steps {
-        build job: 'Code-secret-scanning',
-            parameters: [
-                string(name: 'repository', value: "https://giteux.azure.defra.cloud/imports/$SERVICE_NAME" +".git"),
-                string(name: 'branch', value: "master")
-            ]
-      }
+    agent { label 'autoNodeLive' }
+    environment {
+        SERVICE_NAME = "spring-boot-parent"
+        JAVA_HOME = "/usr/lib/jvm/temurin-11-jdk-amd64"
+    }
+    options {
+        ansiColor('xterm')
+        timestamps()
+        disableConcurrentBuilds()
+    }
+    parameters {
+        booleanParam(name: 'PUSH_TO_ARTIFACTORY', defaultValue: false, description: 'Do you want to push hotfix to artifactory?')
+        string(name: 'AFFECTED_VERSION', defaultValue: null, description: 'Enter affected version to be hotfixed e.g 2.0.103')
+        string(name: 'HOTFIX_VERSION', defaultValue: '1', description: 'Enter hotfix version (1 if it’s the 1st time patching this release version)')
     }
 
-    stage('Package') {
-      steps {
-        getFile 'settings/maven.xml'
-        sh 'mvn -f pom.xml resources:resources --settings ./settings/maven.xml'
-        sh 'mvn -f pom.xml package --settings ./settings/maven.xml'
-      }
-    }
-
-    stage('Deploy Maven Artifact') {
-      when {
-        environment name: 'BRANCH_NAME', value: 'master'
-      }
-
-      steps {
-        mvnDeploy("${BRANCH_NAME}", "pom.xml")
-      }
-    }
-
-    stage('===HOTFIX=== Deploy Maven Artifact') {
-        when {
-            allOf{
-                branch 'hotfix/**'
-                expression { params.PUSH_TO_ARTIFACTORY == true }
-                expression { params.AFFECTED_VERSION != null }
+    stages {
+        stage('Code Secret Scanning') {
+            when {
+                expression { deployables.contains(SERVICE_NAME) }
+            }
+            steps {
+                build job: 'Code-secret-scanning',
+                        parameters: [
+                                string(name: 'repository', value: "https://giteux.azure.defra.cloud/imports/$SERVICE_NAME" + ".git"),
+                                string(name: 'branch', value: "master")
+                        ]
             }
         }
-        steps {
-            mvnDeploy("${BRANCH_NAME}", "pom.xml", true)
+
+        stage('Package') {
+            steps {
+                getFile 'settings/maven.xml'
+                sh 'mvn -f pom.xml resources:resources --settings ./settings/maven.xml'
+                sh 'mvn -f pom.xml package --settings ./settings/maven.xml'
+            }
+        }
+
+        stage('Deploy Maven Artifact') {
+            when {
+                environment name: 'BRANCH_NAME', value: 'master'
+            }
+
+            steps {
+                mvnDeploy("${BRANCH_NAME}", "pom.xml")
+            }
+        }
+
+        stage('===HOTFIX=== Deploy Maven Artifact') {
+            when {
+                allOf {
+                    branch 'hotfix/**'
+                    expression { params.PUSH_TO_ARTIFACTORY == true }
+                    expression { params.AFFECTED_VERSION != null }
+                }
+            }
+            steps {
+                mvnDeploy("${BRANCH_NAME}", "pom.xml", true)
+            }
         }
     }
-  }
 
-  post {
-      always {
-        step([$class: 'WsCleanup'])
-      }
-      failure {
-        notifySlack("BUILD OF ${SERVICE_NAME} HAS FAILED: ${BUILD_URL}", "#FF9FA1")
-      }
-  }
+    post {
+        always {
+            step([$class: 'WsCleanup'])
+        }
+        failure {
+            notifyTeams('red', "JOB: ${env.JOB_NAME} BUILD NUMBER: ${env.BUILD_NUMBER}", 'FAILED', 'mergeNotifications')
+            updateGitlabCommitStatus name: 'build', state: 'failed'
+        }
+        success {
+            notifyTeams('green', "JOB: ${env.JOB_NAME} BUILD NUMBER: ${env.BUILD_NUMBER}", 'SUCCESS', 'mergeNotifications')
+            updateGitlabCommitStatus name: 'build', state: 'success'
+        }
+    }
 }


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | Lewis Birks (Kainos) |
> | **GitLab Project** | [imports/spring-boot-parent](https://giteux.azure.defra.cloud/imports/spring-boot-parent) |
> | **GitLab Merge Request** | [fix(ci): Report status to teams and use ...](https://giteux.azure.defra.cloud/imports/spring-boot-parent/merge_requests/301) |
> | **GitLab MR Number** | [301](https://giteux.azure.defra.cloud/imports/spring-boot-parent/merge_requests/301) |
> | **Date Originally Opened** | Wed, 24 May 2023 |
> | **Approved on GitLab by** | Jana Latzberg (Kainos), Rob Marks, kamil mojek (KAINOS) |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

### :book: Changes:
* Report status to teams in post block
* Use ephemeral jenkins nodes