### PR TITLE
IMTA-15074: fix purpose exit date not null validation when temp admission horses

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
 
     <tracesx.common.version>2.0.26</tracesx.common.version>
     <tracesx.common.security.version>2.0.22</tracesx.common.security.version>
-    <tracesx.notification.schema.version>1.0.300</tracesx.notification.schema.version>
+    <tracesx.notification.schema.version>1.0.301</tracesx.notification.schema.version>
     <applicationinsights.version>2.6.3</applicationinsights.version>
     <azure.applicationinsights.springboot.starter.version>2.6.3</azure.applicationinsights.springboot.starter.version>
     <azure.springboot.metricsstarter.version>2.3.5</azure.springboot.metricsstarter.version>


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | Thomas Seelig (Kainos) |
> | **GitLab Project** | [imports/spring-boot-parent](https://giteux.azure.defra.cloud/imports/spring-boot-parent) |
> | **GitLab Merge Request** | [IMTA-15074: fix purpose exit date not nu...](https://giteux.azure.defra.cloud/imports/spring-boot-parent/merge_requests/320) |
> | **GitLab MR Number** | [320](https://giteux.azure.defra.cloud/imports/spring-boot-parent/merge_requests/320) |
> | **Date Originally Opened** | Mon, 18 Sep 2023 |
> | **Approved on GitLab by** | Abhishek Dutt (Kainos), Jana Latzberg (Kainos), Peter Rooke (Kainos), Shawn Chan (Kainos), prabash balasuriya (kainos) |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

### :link: [Jira Ticket - IMTA-15074](https://eaflood.atlassian.net/browse/IMTA-15074)

### :building_construction: [Jenkins Pipeline](https://jenkins-imports.azure.defra.cloud/job/spring-boot-parent/job/bugfix%252FIMTA-15074-temp-admission-horse-exit-date-not-validated/)

### :book: Changes:
* bump imports-notification-schema to make purpose exit date required field for cheda's with for import or admission as Temporary Admission Horses