### PR TITLE
IMTA-16293: Remove junit 4 dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -73,7 +73,6 @@
     <owasp.version>8.4.0</owasp.version>
     <shared-resources.version>1.0.0</shared-resources.version>
     <snakeyaml.version>2.1</snakeyaml.version>
-    <surefire.junit4.version>2.22.0</surefire.junit4.version>
     <woodstox-core.version>6.5.1</woodstox-core.version>
   </properties>
 
@@ -165,11 +164,6 @@
         <groupId>com.google.guava</groupId>
         <artifactId>guava</artifactId>
         <version>${guava.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.maven.surefire</groupId>
-        <artifactId>surefire-junit4</artifactId>
-        <version>${surefire.junit4.version}</version>
       </dependency>
       <dependency>
         <groupId>nl.jqno.equalsverifier</groupId>
@@ -352,11 +346,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.apache.maven.surefire</groupId>
-      <artifactId>surefire-junit4</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>nl.jqno.equalsverifier</groupId>
       <artifactId>equalsverifier</artifactId>
       <scope>test</scope>
@@ -418,11 +407,6 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-surefire-plugin</artifactId>
-          <configuration>
-            <argLine>
-              ${argLine} --illegal-access=permit
-            </argLine>
-          </configuration>
         </plugin>
         <plugin>
           <groupId>org.codehaus.mojo</groupId>


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | Lewis Birks (Kainos) |
> | **GitLab Project** | [imports/spring-boot-parent](https://giteux.azure.defra.cloud/imports/spring-boot-parent) |
> | **GitLab Merge Request** | [IMTA-16293: Remove junit 4 dependencies](https://giteux.azure.defra.cloud/imports/spring-boot-parent/merge_requests/385) |
> | **GitLab MR Number** | [385](https://giteux.azure.defra.cloud/imports/spring-boot-parent/merge_requests/385) |
> | **Date Originally Opened** | Wed, 6 Mar 2024 |
> | **Approved on GitLab by** | Ajith Thomas (Kainos), Apurva Jhunjhunwala (Kainos), Eric Kennedy (Kainos), Jana Latzberg (Kainos), philip munaawa1 (Kainos) |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

### :link: Ticket: https://eaflood.atlassian.net/browse/IMTA-16293

### :book: Changes:
* Remove the following dependencies:
  * surefire-junit4
     * As we are migrating to junit 5 it was causing issues when reporting test failures, causing tests that fail to be silently ignored and have the overall result still be passed
  * testng
     * We use junit 5
* Remove deprecated commandline arg

Before:

```text
[INFO] Running uk.gov.defra.tracesx.permissions.PropertySetterTest
2024-03-06T15:10:59.603Z  WARN 11097 --- [permissions] [           main] o.j.p.l.c.CompositeTestExecutionListener : TestExecutionListener [org.apache.maven.surefire.junitplatform.RunListenerAdapter] threw exception for method: executionFinished(TestIdentifier [uniqueId = [engine:junit-jupiter]/[class:uk.gov.defra.tracesx.permissions.PropertySetterTest]/[method:testPropertySetter()], parentId = [engine:junit-jupiter]/[class:uk.gov.defra.tracesx.permissions.PropertySetterTest], displayName = 'testPropertySetter()', legacyReportingName = 'testPropertySetter()', source = MethodSource [className = 'uk.gov.defra.tracesx.permissions.PropertySetterTest', methodName = 'testPropertySetter', methodParameterTypes = ''], tags = [], type = TEST], TestExecutionResult [status = FAILED, throwable = org.opentest4j.AssertionFailedError: 
expected: null
 but was: "20"])

java.lang.IncompatibleClassChangeError: Class org.apache.maven.surefire.report.PojoStackTraceWriter does not implement the requested interface org.apache.maven.surefire.api.report.StackTraceWriter
	at org.apache.maven.surefire.booter.spi.EventChannelEncoder$StackTrace.<init>(EventChannelEncoder.java:404)
	at org.apache.maven.surefire.booter.spi.EventChannelEncoder.encode(EventChannelEncoder.java:336)
	at org.apache.maven.surefire.booter.spi.EventChannelEncoder.encode(EventChannelEncoder.java:273)
	at org.apache.maven.surefire.booter.spi.EventChannelEncoder.testFailed(EventChannelEncoder.java:142)
	at org.apache.maven.surefire.api.booter.ForkingRunListener.testFailed(ForkingRunListener.java:84)
	at org.apache.maven.surefire.junitplatform.RunListenerAdapter.executionFinished(RunListenerAdapter.java:143)
	at org.junit.platform.launcher.core.CompositeTestExecutionListener.lambda$executionFinished$10(CompositeTestExecutionListener.java:73)
	at org.junit.platform.launcher.core.CompositeTestExecutionListener.lambda$notifyEach$19(CompositeTestExecutionListener.java:102)
	at org.junit.platform.commons.util.CollectionUtils.forEachInReverseOrder(CollectionUtils.java:221)
	at org.junit.platform.launcher.core.IterationOrder$2.forEach(IterationOrder.java:30)
	at org.junit.platform.launcher.core.CompositeTestExecutionListener.notifyEach(CompositeTestExecutionListener.java:100)
	at org.junit.platform.launcher.core.CompositeTestExecutionListener.executionFinished(CompositeTestExecutionListener.java:72)
	at org.junit.platform.launcher.core.ExecutionListenerAdapter.executionFinished(ExecutionListenerAdapter.java:56)
	at org.junit.platform.launcher.core.CompositeEngineExecutionListener.lambda$executionFinished$6(CompositeEngineExecutionListener.java:59)
	at org.junit.platform.launcher.core.CompositeEngineExecutionListener.lambda$notifyEach$11(CompositeEngineExecutionListener.java:74)
	at org.junit.platform.commons.util.CollectionUtils.forEachInReverseOrder(CollectionUtils.java:221)
	at org.junit.platform.launcher.core.IterationOrder$2.forEach(IterationOrder.java:30)
	at org.junit.platform.launcher.core.CompositeEngineExecutionListener.notifyEach(CompositeEngineExecutionListener.java:72)
	at org.junit.platform.launcher.core.CompositeEngineExecutionListener.executionFinished(CompositeEngineExecutionListener.java:58)
	at org.junit.platform.launcher.core.DelegatingEngineExecutionListener.executionFinished(DelegatingEngineExecutionListener.java:46)
	at org.junit.platform.launcher.core.StackTracePruningEngineExecutionListener.executionFinished(StackTracePruningEngineExecutionListener.java:46)
	at org.junit.platform.launcher.core.DelegatingEngineExecutionListener.executionFinished(DelegatingEngineExecutionListener.java:46)
	at org.junit.platform.launcher.core.OutcomeDelayingEngineExecutionListener.executionFinished(OutcomeDelayingEngineExecutionListener.java:63)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.reportCompletion(NodeTestTask.java:195)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.execute(NodeTestTask.java:100)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1511)
	at org.junit.platform.engine.support.hierarchical.SameThreadHierarchicalTestExecutorService.invokeAll(SameThreadHierarchicalTestExecutorService.java:41)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$6(NodeTestTask.java:155)
	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$8(NodeTestTask.java:141)
	at org.junit.platform.engine.support.hierarchical.Node.around(Node.java:137)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$9(NodeTestTask.java:139)
	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.executeRecursively(NodeTestTask.java:138)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.execute(NodeTestTask.java:95)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1511)
	at org.junit.platform.engine.support.hierarchical.SameThreadHierarchicalTestExecutorService.invokeAll(SameThreadHierarchicalTestExecutorService.java:41)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$6(NodeTestTask.java:155)
	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$8(NodeTestTask.java:141)
	at org.junit.platform.engine.support.hierarchical.Node.around(Node.java:137)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$9(NodeTestTask.java:139)
	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.executeRecursively(NodeTestTask.java:138)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.execute(NodeTestTask.java:95)
	at org.junit.platform.engine.support.hierarchical.SameThreadHierarchicalTestExecutorService.submit(SameThreadHierarchicalTestExecutorService.java:35)
	at org.junit.platform.engine.support.hierarchical.HierarchicalTestExecutor.execute(HierarchicalTestExecutor.java:57)
	at org.junit.platform.engine.support.hierarchical.HierarchicalTestEngine.execute(HierarchicalTestEngine.java:54)
	at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:198)
	at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:169)
	at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:93)
	at org.junit.platform.launcher.core.EngineExecutionOrchestrator.lambda$execute$0(EngineExecutionOrchestrator.java:58)
	at org.junit.platform.launcher.core.EngineExecutionOrchestrator.withInterceptedStreams(EngineExecutionOrchestrator.java:141)
	at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:57)
	at org.junit.platform.launcher.core.DefaultLauncher.execute(DefaultLauncher.java:103)
	at org.junit.platform.launcher.core.DefaultLauncher.execute(DefaultLauncher.java:85)
	at org.junit.platform.launcher.core.DelegatingLauncher.execute(DelegatingLauncher.java:47)
	at org.apache.maven.surefire.junitplatform.LazyLauncher.execute(LazyLauncher.java:56)
	at org.apache.maven.surefire.junitplatform.JUnitPlatformProvider.execute(JUnitPlatformProvider.java:184)
	at org.apache.maven.surefire.junitplatform.JUnitPlatformProvider.invokeAllTests(JUnitPlatformProvider.java:148)
	at org.apache.maven.surefire.junitplatform.JUnitPlatformProvider.invoke(JUnitPlatformProvider.java:122)
	at org.apache.maven.surefire.booter.ForkedBooter.runSuitesInProcess(ForkedBooter.java:385)
	at org.apache.maven.surefire.booter.ForkedBooter.execute(ForkedBooter.java:162)
	at org.apache.maven.surefire.booter.ForkedBooter.run(ForkedBooter.java:507)
	at org.apache.maven.surefire.booter.ForkedBooter.main(ForkedBooter.java:495)

[INFO] Tests run: 0, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.011 s -- in uk.gov.defra.tracesx.permissions.PropertySetterTest
```
after
```text
[INFO] Running uk.gov.defra.tracesx.permissions.PropertySetterTest
[ERROR] Tests run: 1, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 0.008 s <<< FAILURE! -- in uk.gov.defra.tracesx.permissions.PropertySetterTest
[ERROR] uk.gov.defra.tracesx.permissions.PropertySetterTest.testPropertySetter -- Time elapsed: 0.006 s <<< FAILURE!
org.opentest4j.AssertionFailedError: 

expected: null
 but was: "20"
	at java.base/jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
	at java.base/jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:77)
	at java.base/jdk.internal.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
	at java.base/java.lang.reflect.Constructor.newInstanceWithCaller(Constructor.java:499)
	at uk.gov.defra.tracesx.permissions.PropertySetterTest.testPropertySetter(PropertySetterTest.java:20)
	at java.base/java.lang.reflect.Method.invoke(Method.java:568)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1511)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1511)

```