### PR TITLE
IMTA-19407 remove dependency-check-maven from build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -567,10 +567,6 @@
         <artifactId>jacoco-maven-plugin</artifactId>
       </plugin>
       <plugin>
-        <groupId>org.owasp</groupId>
-        <artifactId>dependency-check-maven</artifactId>
-      </plugin>
-      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-checkstyle-plugin</artifactId>
       </plugin>


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | @crosslandwa |
> | **GitLab Project** | [imports/spring-boot-parent](https://giteux.azure.defra.cloud/imports/spring-boot-parent) |
> | **GitLab Merge Request** | [IMTA-19407 remove dependency-check-maven...](https://giteux.azure.defra.cloud/imports/spring-boot-parent/merge_requests/426) |
> | **GitLab MR Number** | [426](https://giteux.azure.defra.cloud/imports/spring-boot-parent/merge_requests/426) |
> | **Date Originally Opened** | Wed, 4 Dec 2024 |
> | **Approved on GitLab by** | @dannyjo, @howzat, Harrison Duffield (Kainos) |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

Removes dependency-check-maven from build of this library (but keeps the pluginManagement definition in-tact for other microservices that rely on the configuration in this library)