### PR TITLE
remove Kainos Teams notifications from Jenkins pipelines

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -102,11 +102,9 @@ pipeline {
             step([$class: 'WsCleanup'])
         }
         failure {
-            notifyTeams('red', "JOB: ${env.JOB_NAME} BUILD NUMBER: ${env.BUILD_NUMBER}", 'FAILED', 'mergeNotifications')
             updateGitlabCommitStatus name: 'build', state: 'failed'
         }
         success {
-            notifyTeams('green', "JOB: ${env.JOB_NAME} BUILD NUMBER: ${env.BUILD_NUMBER}", 'SUCCESS', 'mergeNotifications')
             updateGitlabCommitStatus name: 'build', state: 'success'
         }
     }


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | @manicminer |
> | **GitLab Project** | [imports/spring-boot-parent](https://giteux.azure.defra.cloud/imports/spring-boot-parent) |
> | **GitLab Merge Request** | [remove Kainos Teams notifications from J...](https://giteux.azure.defra.cloud/imports/spring-boot-parent/merge_requests/430) |
> | **GitLab MR Number** | [430](https://giteux.azure.defra.cloud/imports/spring-boot-parent/merge_requests/430) |
> | **Date Originally Opened** | Wed, 2 Apr 2025 |
> | **Approved on GitLab by** | @crosslandwa |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

_No description_