### PR TITLE
IMTA-7561 Update spring-boot-starter-parent to 2.3.1.RELEASE

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>2.2.5.RELEASE</version>
+    <version>2.3.1.RELEASE</version>
   </parent>
 
   <distributionManagement>


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | David McKinney (KAINOS) |
> | **GitLab Project** | [imports/spring-boot-parent](https://giteux.azure.defra.cloud/imports/spring-boot-parent) |
> | **GitLab Merge Request** | [IMTA-7561 Update spring-boot-starter-par...](https://giteux.azure.defra.cloud/imports/spring-boot-parent/merge_requests/71) |
> | **GitLab MR Number** | [71](https://giteux.azure.defra.cloud/imports/spring-boot-parent/merge_requests/71) |
> | **Date Originally Opened** | Wed, 17 Jun 2020 |
> | **Approved on GitLab by** | Sean Treanor (KAINOS), sam rodgers (KAINOS) |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

_No description_