### PR TITLE
IMTA-8185 - Bumped common-security to 2.0.8 and notification-schema to 1.0.92

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,8 +34,8 @@
     <java.version>11</java.version>
 
     <tracesx.common.version>2.0.16</tracesx.common.version>
-    <tracesx.common.security.version>2.0.7</tracesx.common.security.version>
-    <tracesx.notification.schema.version>1.0.91</tracesx.notification.schema.version>
+    <tracesx.common.security.version>2.0.8</tracesx.common.security.version>
+    <tracesx.notification.schema.version>1.0.92</tracesx.notification.schema.version>
     <adal4j.version>1.6.4</adal4j.version>
     <applicationinsights.version>2.5.0</applicationinsights.version>
     <azure.springboot.metricsstarter.version>2.1.7</azure.springboot.metricsstarter.version>


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | Robert Hall (KAINOS) |
> | **GitLab Project** | [imports/spring-boot-parent](https://giteux.azure.defra.cloud/imports/spring-boot-parent) |
> | **GitLab Merge Request** | [IMTA-8185 - Bumped common-security to 2....](https://giteux.azure.defra.cloud/imports/spring-boot-parent/merge_requests/101) |
> | **GitLab MR Number** | [101](https://giteux.azure.defra.cloud/imports/spring-boot-parent/merge_requests/101) |
> | **Date Originally Opened** | Thu, 3 Sep 2020 |
> | **Approved on GitLab by** | Stephen McVeigh, Stephen McVeigh, Stephen McVeigh, daniel brennan (KAINOS), dominik henjes (KAINOS), marcus bond (KAINOS) |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

Bumped spring-common-security from 2.0.7 -> 2.0.8 and notification-schema from 1.0.91 -> 1.0.92