### PR TITLE
IMTA-8179: Increase version of IPAFFS schema

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
 
     <tracesx.common.version>2.0.16</tracesx.common.version>
     <tracesx.common.security.version>2.0.8</tracesx.common.security.version>
-    <tracesx.notification.schema.version>1.0.92</tracesx.notification.schema.version>
+    <tracesx.notification.schema.version>1.0.95</tracesx.notification.schema.version>
     <adal4j.version>1.6.4</adal4j.version>
     <applicationinsights.version>2.5.0</applicationinsights.version>
     <azure.springboot.metricsstarter.version>2.1.7</azure.springboot.metricsstarter.version>


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | iwan roberts (KAINOS) |
> | **GitLab Project** | [imports/spring-boot-parent](https://giteux.azure.defra.cloud/imports/spring-boot-parent) |
> | **GitLab Merge Request** | [IMTA-8179: Increase version of IPAFFS sc...](https://giteux.azure.defra.cloud/imports/spring-boot-parent/merge_requests/102) |
> | **GitLab MR Number** | [102](https://giteux.azure.defra.cloud/imports/spring-boot-parent/merge_requests/102) |
> | **Date Originally Opened** | Fri, 11 Sep 2020 |
> | **Approved on GitLab by** | David McKinney (KAINOS), Stephen McVeigh, kamil mojek (KAINOS) |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

The purpose of this change is to add the latest version of the IPAFFS schema so that the fix for CHED-PP commodities with no associated species can be addressed.