### PR TITLE
IMTA-9803: Bump schema version for default decision option validation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
 
     <tracesx.common.version>2.0.20</tracesx.common.version>
     <tracesx.common.security.version>2.0.13</tracesx.common.security.version>
-    <tracesx.notification.schema.version>1.0.199</tracesx.notification.schema.version>
+    <tracesx.notification.schema.version>1.0.200</tracesx.notification.schema.version>
     <adal4j.version>1.6.4</adal4j.version>
     <applicationinsights.version>2.6.3</applicationinsights.version>
     <azure.springboot.metricsstarter.version>2.1.7</azure.springboot.metricsstarter.version>


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | Ben Doherty (Kainos) |
> | **GitLab Project** | [imports/spring-boot-parent](https://giteux.azure.defra.cloud/imports/spring-boot-parent) |
> | **GitLab Merge Request** | [IMTA-9803: Bump schema version for defau...](https://giteux.azure.defra.cloud/imports/spring-boot-parent/merge_requests/214) |
> | **GitLab MR Number** | [214](https://giteux.azure.defra.cloud/imports/spring-boot-parent/merge_requests/214) |
> | **Date Originally Opened** | Tue, 12 Oct 2021 |
> | **Approved on GitLab by** | Callum Atwal (kainos), Jahir, Sifat (KAINOS), Nicholas Martin, kamil mojek (KAINOS), lee mason (KAINOS) |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

### :link: Ticket: https://eaflood.atlassian.net/browse/IMTA-9803
### :book: Changes:
*  Bump notification schema version for default decision option validation