### PR TITLE
IMTA-10627: Bumping schema version to 1.0.207

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
 
     <tracesx.common.version>2.0.20</tracesx.common.version>
     <tracesx.common.security.version>2.0.13</tracesx.common.security.version>
-    <tracesx.notification.schema.version>1.0.206</tracesx.notification.schema.version>
+    <tracesx.notification.schema.version>1.0.207</tracesx.notification.schema.version>
     <adal4j.version>1.6.4</adal4j.version>
     <applicationinsights.version>2.6.3</applicationinsights.version>
     <azure.springboot.metricsstarter.version>2.1.7</azure.springboot.metricsstarter.version>


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | Sean Treanor (KAINOS) |
> | **GitLab Project** | [imports/spring-boot-parent](https://giteux.azure.defra.cloud/imports/spring-boot-parent) |
> | **GitLab Merge Request** | [IMTA-10627: Bumping schema version to 1....](https://giteux.azure.defra.cloud/imports/spring-boot-parent/merge_requests/222) |
> | **GitLab MR Number** | [222](https://giteux.azure.defra.cloud/imports/spring-boot-parent/merge_requests/222) |
> | **Date Originally Opened** | Mon, 22 Nov 2021 |
> | **Approved on GitLab by** | Callum Atwal (kainos), iwan roberts (KAINOS), lee mason (KAINOS) |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

### :link: Ticket: https://eaflood.atlassian.net/browse/IMTA-10627
### :book: Changes:
* Bumping schema version to `1.0.207`