### PR TITLE
Add new code secret scanning stage for spring boot parent

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,3 +1,8 @@
+import defra.pipeline.config.Config;
+import defra.pipeline.deploy.DeployQueries;
+
+def deployables = DeployQueries.getListOfDeployableComponents(Config.getPropertyValue("secretscanningDeploymentList", this), this)
+
 @Library('pipeline-library') _
 
 pipeline {
@@ -17,6 +22,19 @@ pipeline {
   }
 
   stages {
+
+    stage('Code Secret Scanning'){
+      when {
+        expression {deployables.contains(SERVICE_NAME)}
+      }
+      steps {
+        build job: 'Code-secret-scanning',
+            parameters: [
+                string(name: 'repository', value: "https://giteux.azure.defra.cloud/imports/$SERVICE_NAME" +".git"),
+                string(name: 'branch', value: "master")
+            ]
+      }
+    }
 
     stage('Package') {
       steps {


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | willson onuoha (Kainos) |
> | **GitLab Project** | [imports/spring-boot-parent](https://giteux.azure.defra.cloud/imports/spring-boot-parent) |
> | **GitLab Merge Request** | [Add new code secret scanning stage for s...](https://giteux.azure.defra.cloud/imports/spring-boot-parent/merge_requests/266) |
> | **GitLab MR Number** | [266](https://giteux.azure.defra.cloud/imports/spring-boot-parent/merge_requests/266) |
> | **Date Originally Opened** | Mon, 9 Jan 2023 |
> | **Approved on GitLab by** | Grzegorz Sowinski (Admin), Nicholas Martin |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

# Summary

This new stage is required for scanning the master repository for any secret
password or token that shouldn't be made public

# Test
- https://jenkins-imports.azure.defra.cloud/job/spring-boot-parent/job/feature%252FIMTA-12534-add-code-secret-scanning-stage-spring-boot-parent/1/console
![image](/uploads/c1e186c2d190d2ee0d2a6f009c8f57f0/image.png)