### PR TITLE
IMTA-13471 Upgrade Spring Boot to use Version 2.7.7 (Spring Security 5.7.6)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>2.7.1</version>
+    <version>2.7.7</version>
   </parent>
 
   <distributionManagement>


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | peter norton (Kainos) |
> | **GitLab Project** | [imports/spring-boot-parent](https://giteux.azure.defra.cloud/imports/spring-boot-parent) |
> | **GitLab Merge Request** | [IMTA-13471 Upgrade Spring Boot to use Ve...](https://giteux.azure.defra.cloud/imports/spring-boot-parent/merge_requests/269) |
> | **GitLab MR Number** | [269](https://giteux.azure.defra.cloud/imports/spring-boot-parent/merge_requests/269) |
> | **Date Originally Opened** | Thu, 12 Jan 2023 |
> | **Approved on GitLab by** | Apurva Jhunjhunwala (Kainos), Charles.Luo, prabash balasuriya (kainos) |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

### :link: [Jira Ticket](https://eaflood.atlassian.net/browse/IMTA-13471)

### :building_construction: [Jenkins Pipeline](https://jenkins-imports.azure.defra.cloud/job/spring-boot-parent/job/bugfix%2FIMTA-13471-vulnerability-spring-security-5.7.2/)

### :book: Changes:

- Adjust Spring Boot to use Version 2.7.7 to resolve vulnerability in earlier version of Spring Security