### PR TITLE
IMTA-13545: enforce dependency version jackson-dataformat-xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -193,6 +193,11 @@
         <version>${json-schema-java7.version}</version>
       </dependency>
       <dependency>
+        <groupId>com.fasterxml.jackson.dataformat</groupId>
+        <artifactId>jackson-dataformat-xml</artifactId>
+        <version>2.14.1</version>
+      </dependency>
+      <dependency>
         <groupId>com.neovisionaries</groupId>
         <artifactId>nv-i18n</artifactId>
         <version>${neovisionaries.version}</version>


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | Thomas Seelig (Kainos) |
> | **GitLab Project** | [imports/spring-boot-parent](https://giteux.azure.defra.cloud/imports/spring-boot-parent) |
> | **GitLab Merge Request** | [IMTA-13545: enforce dependency version j...](https://giteux.azure.defra.cloud/imports/spring-boot-parent/merge_requests/272) |
> | **GitLab MR Number** | [272](https://giteux.azure.defra.cloud/imports/spring-boot-parent/merge_requests/272) |
> | **Date Originally Opened** | Mon, 23 Jan 2023 |
> | **Approved on GitLab by** | Zuzanna Megger (Kainos), prabash balasuriya (kainos), venugopal gummadala (Kainos) |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

### :link: Ticket: [IMTA-13545](https://eaflood.atlassian.net/browse/IMTA-13545)

### :construction_site: [Jenkins Pipeline](https://jenkins-imports.azure.defra.cloud/job/spring-boot-parent/job/bugfix%252FIMTA-13545-enforce-dependency-version/)

### :book: Changes:

resolve some CVE's tied to jackson-dataformat-xml version being used and resolve dependency conflict being caused by version of woodstox-core used in jackson-dataformat-xml.