### PR TITLE
IMTA-13449: Pointing to latest version of notification schema

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
 
     <tracesx.common.version>2.0.24</tracesx.common.version>
     <tracesx.common.security.version>2.0.17</tracesx.common.security.version>
-    <tracesx.notification.schema.version>1.0.253</tracesx.notification.schema.version>
+    <tracesx.notification.schema.version>1.0.254</tracesx.notification.schema.version>
     <applicationinsights.version>2.6.3</applicationinsights.version>
     <azure.springboot.metricsstarter.version>2.3.5</azure.springboot.metricsstarter.version>
     <azure.applicationinsights.springboot.starter.version>2.6.3</azure.applicationinsights.springboot.starter.version>


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | Adam McNeilly (Kainos) |
> | **GitLab Project** | [imports/spring-boot-parent](https://giteux.azure.defra.cloud/imports/spring-boot-parent) |
> | **GitLab Merge Request** | [IMTA-13449: Pointing to latest version o...](https://giteux.azure.defra.cloud/imports/spring-boot-parent/merge_requests/275) |
> | **GitLab MR Number** | [275](https://giteux.azure.defra.cloud/imports/spring-boot-parent/merge_requests/275) |
> | **Date Originally Opened** | Tue, 24 Jan 2023 |
> | **Approved on GitLab by** | Charles.Luo, Jun Jun Alfante (Kainos), peter norton (Kainos) |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

### :link: [Jira Ticket](https://eaflood.atlassian.net/browse/IMTA-13449)

### :chart_with_upwards_trend: [SonarQube Report](<SONARQUBE LINK>)

### :building_construction: [Jenkins Pipeline](https://jenkins-imports.azure.defra.cloud/job/spring-boot-parent/job/revert%2FIMTA-13449-pointing-to-latest-version-of-notification-schema/)

### :book: Changes:
* Updating version due to reverting https://giteux.azure.defra.cloud/imports/imports-notification-schema/merge_requests/297

### :white_check_mark: Selenium Test Run:

PENDING