### PR TITLE
IMTA-13545: enforce woodstox core version and bump azure-identity

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
     <maven.checkstyle.version>3.0.0</maven.checkstyle.version>
     <maven-release-plugin.version>2.5.3</maven-release-plugin.version>
     <mssql.jdbc.version>9.2.1.jre11</mssql.jdbc.version>
-    <azureidentity.version>1.4.3</azureidentity.version>
+    <azureidentity.version>1.7.3</azureidentity.version>
     <neovisionaries.version>1.22</neovisionaries.version>
     <org.everit.json.schema.version>1.12.1</org.everit.json.schema.version>
     <org.owasp.encoder.version>1.2.2</org.owasp.encoder.version>
@@ -191,6 +191,11 @@
         <groupId>com.doctusoft</groupId>
         <artifactId>json-schema-java7</artifactId>
         <version>${json-schema-java7.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.fasterxml.woodstox</groupId>
+        <artifactId>woodstox-core</artifactId>
+        <version>6.4.0</version>
       </dependency>
       <dependency>
         <groupId>com.neovisionaries</groupId>


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | Thomas Seelig (Kainos) |
> | **GitLab Project** | [imports/spring-boot-parent](https://giteux.azure.defra.cloud/imports/spring-boot-parent) |
> | **GitLab Merge Request** | [IMTA-13545: enforce woodstox core versio...](https://giteux.azure.defra.cloud/imports/spring-boot-parent/merge_requests/277) |
> | **GitLab MR Number** | [277](https://giteux.azure.defra.cloud/imports/spring-boot-parent/merge_requests/277) |
> | **Date Originally Opened** | Fri, 27 Jan 2023 |
> | **Approved on GitLab by** | Carl Evans (KAINOS), Ethan Weatherup, Jana Latzberg (Kainos), Marina Tihova, prabash balasuriya (kainos), venugopal gummadala (Kainos) |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

### :link: Ticket: [IMTA-13545](https://eaflood.atlassian.net/browse/IMTA-13545)

### :construction_site: [Jenkins Pipeline](https://jenkins-imports.azure.defra.cloud/job/spring-boot-parent/job/bugfix%252FIMTA-13545-woodstox-core-CVE/)

### :book: Changes:

resolve some CVE's tied to woodstox-core version being used.

[CVE-2022040152](https://nvd.nist.gov/vuln/detail/CVE-2022-40152)