### PR TITLE
IMTA-13547: Add common logging dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
 
     <java.version>11</java.version>
 
-    <tracesx.common.version>2.0.24</tracesx.common.version>
+    <tracesx.common.version>2.0.26</tracesx.common.version>
     <tracesx.common.security.version>2.0.17</tracesx.common.security.version>
     <tracesx.notification.schema.version>1.0.255</tracesx.notification.schema.version>
     <applicationinsights.version>2.6.3</applicationinsights.version>
@@ -82,6 +82,11 @@
       <dependency>
         <groupId>uk.gov.defra.tracesx</groupId>
         <artifactId>TracesX-SpringBoot-Common-Event</artifactId>
+        <version>${tracesx.common.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>uk.gov.defra.tracesx</groupId>
+        <artifactId>TracesX-SpringBoot-Common-Logging</artifactId>
         <version>${tracesx.common.version}</version>
       </dependency>
       <dependency>
@@ -249,6 +254,10 @@
     <dependency>
       <groupId>uk.gov.defra.tracesx</groupId>
       <artifactId>TracesX-SpringBoot-CommonSecurity-Config</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>uk.gov.defra.tracesx</groupId>
+      <artifactId>TracesX-SpringBoot-Common-Logging</artifactId>
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | Reece Bennett (KAINOS) |
> | **GitLab Project** | [imports/spring-boot-parent](https://giteux.azure.defra.cloud/imports/spring-boot-parent) |
> | **GitLab Merge Request** | [IMTA-13547: Add common logging dependenc...](https://giteux.azure.defra.cloud/imports/spring-boot-parent/merge_requests/278) |
> | **GitLab MR Number** | [278](https://giteux.azure.defra.cloud/imports/spring-boot-parent/merge_requests/278) |
> | **Date Originally Opened** | Mon, 30 Jan 2023 |
> | **Approved on GitLab by** | Ethan Weatherup, Eugene Fahy (Kainos), Lewis Birks (Kainos), Marina Tihova, prabash balasuriya (kainos) |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

### :link: [Jira Ticket](https://eaflood.atlassian.net/browse/IMTA-13547)

### :building_construction: [Jenkins Pipeline](https://jenkins-imports.azure.defra.cloud/job/spring-boot-parent/job/feature%2FIMTA-13547-add-startup-logging/)

### :book: Changes:

- Add TracesX-SpringBoot-Common-Logging dependency
- Bump TracesX-Common version to 2.0.26